### PR TITLE
chore: REUSE information in README, use correct dep5

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,8 +1,8 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: PrimeTime
+Upstream-Name: cloud-primetime
 Upstream-Contact: Robert Wetzold <robert.wetzold@sap.com>
 Source: https://github.com/SAP/cloud-primetime
 
 Files: *
-Copyright: 2021 SAP SE or an SAP affiliate company and OwnID contributors
+Copyright: 2019-2021 SAP SE or an SAP affiliate company and cloud-primetime contributors
 License: Apache-2.0

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019-21 SAP SE or an SAP affiliate company
+   Copyright 2019-2021 SAP SE or an SAP affiliate company and cloud-primetime contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # PrimeTime
+
+[![REUSE status](https://api.reuse.software/badge/github.com/SAP/cloud-primetime)](https://api.reuse.software/info/github.com/SAP/cloud-primetime)
+
 ## Introduction
 PrimeTime is a digital signage solution. It helps you to easily manage contents for screens of all types - supporting many different formats, custom templates as well as public and secured content where a prior login is required. It also acts as a technical showcase of how SAP Cloud Platform can be utilized.
 
@@ -81,4 +84,4 @@ Contributions are very welcome.
   - Evaluate switching to TypeScript 
 
 ## License
-Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License v2, except as noted otherwise in the [LICENSE](/LICENSE) file.
+Copyright (c) 2021 SAP SE or an SAP affiliate company and cloud-primetime contributors. Please see our [LICENSE](LICENSE) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/SAP/cloud-primetime).


### PR DESCRIPTION
In line with SAP OSPO requirements, this PR adds the REUSE Tool links to the README

**Notes:** 
- Please register the repository with the REUSE Tool to complete the integration (see #8 and #9)
- the dep5.txt file was renamed to dep5 (see REUSE spec)

Fixes #7